### PR TITLE
Introduce exynos3470 slsi features et al.

### DIFF
--- a/common.xml
+++ b/common.xml
@@ -2,6 +2,7 @@
 <manifest>
   <project name="Spookcity/android_device_samsung_smdk3470-common" path="device/samsung/smdk3470-common" revision="P" remote="github" />
   <project name="Spookcity/android_hardware_samsung_slsi_exynos3470" path="hardware/samsung_slsi-cm/exynos3470" revision="P" remote="github" />
+  <project name="LineageOS/android_hardware_samsung_slsi-cm_exynos" path="hardware/samsung_slsi-cm/exynos" revision="lineage-16.0" remote="github" />
   <project name="LineageOS/android_packages_apps_FlipFlap" path="packages/apps/FlipFlap" />
   <project name="LineageOS/android_packages_resources_devicesettings" path="packages/resources/devicesettings" /><!-- for FlipFlap -->
   <project name="Spookcity/android_hardware_samsung" path="hardware/samsung" revision="P"/>

--- a/common.xml
+++ b/common.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
   <project name="Spookcity/android_device_samsung_smdk3470-common" path="device/samsung/smdk3470-common" revision="P" remote="github" />
-  <project name="Spookcity/android_hardware_samsung_slsi_exynos3470" path="hardware/samsung_slsi/exynos3470" revision="P" remote="github" />
+  <project name="Spookcity/android_hardware_samsung_slsi_exynos3470" path="hardware/samsung_slsi-cm/exynos3470" revision="P" remote="github" />
   <project name="LineageOS/android_packages_apps_FlipFlap" path="packages/apps/FlipFlap" />
   <project name="LineageOS/android_packages_resources_devicesettings" path="packages/resources/devicesettings" /><!-- for FlipFlap -->
   <project name="Spookcity/android_hardware_samsung" path="hardware/samsung" revision="P"/>

--- a/common.xml
+++ b/common.xml
@@ -3,8 +3,8 @@
   <project name="Spookcity/android_device_samsung_smdk3470-common" path="device/samsung/smdk3470-common" revision="P" remote="github" />
   <project name="Spookcity/android_hardware_samsung_slsi_exynos3470" path="hardware/samsung_slsi-cm/exynos3470" revision="P" remote="github" />
   <project name="LineageOS/android_hardware_samsung_slsi-cm_exynos" path="hardware/samsung_slsi-cm/exynos" revision="lineage-16.0" remote="github" />
-  <project name="LineageOS/android_packages_apps_FlipFlap" path="packages/apps/FlipFlap" />
-  <project name="LineageOS/android_packages_resources_devicesettings" path="packages/resources/devicesettings" /><!-- for FlipFlap -->
+  <project name="LineageOS/android_packages_apps_FlipFlap" path="packages/apps/FlipFlap" revision="lineage-16.0" />
+  <project name="LineageOS/android_packages_resources_devicesettings" path="packages/resources/devicesettings" revision="lineage-16.0" /><!-- for FlipFlap -->
   <project name="Spookcity/android_hardware_samsung" path="hardware/samsung" revision="P"/>
   <project name="Spookcity/android_external_protobuf-compat-2.6" path="external/protobuf-compat-2.6" revision="P"/>
 </manifest>


### PR DESCRIPTION
Hello Spook
so this is the first part of an extensive update to the device tree..

As already discussed, the guards in exynos3470's Android.mk made it ignore its content... I adapted the /Android.mk that it would work with exynos3 and exynos3470 (TARGET_SOC) respectively. Furthermore, I had to patch  some of the files in the subdirs.

I moved our exynos3470 into samsung_slsi-CM folder as to highlight that it is based on the various samsung_slsi-CM repos. As for the exynosutils it also needs samsung_slsi-cm_exynos, that's why I added it here.
With some changes to the source (patches/Wno-...)  I was able to get libstagefrighthw, libmemtrack, exynosutils, libhwjpeg and others compiled and included in the rom (s. commits to exynos3470/smdk3470). I have it running for some days here and everything seems alright so far. I believe it's running smoother although jpegs take a little longer to render maybe.

However, all the samsung_slsi-cm_* repos  appear to be outdated as it seems impossible to include the cm-openmax stuff since these old sources require libgscaler which in turn depends on libmcclient which forms part of mobicore. Mobicore is afaik not possible to implement in custom builds. I guess this is where the new repos would come in (samsung_slsi_exynos/samsung_slsi_openmax) where the openmax stuff seemingly doesn't ultimately depend on mobicore anymore .

As for the camera, I believe it's still not working, although I included some (probably) missing headers in the kernel (one file was already present in directory but not included in Kconfig). I think it might be possible to fix video recording by not relying on the prebuilt omx codecs and use new openmax repo instead. 

Best

